### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ var transifex = require('transifex').createClient(options)
 var gulp = require('gulp')
 
 gulp.task('upstream', function(){
-    gulp.src('path/to/source/language/*')
+    return gulp.src('path/to/source/language/*')
         .pipe(transifex.pushResource())
 })
 ```
@@ -67,7 +67,7 @@ var transifex = require('transifex').createClient(options)
 var gulp = require('gulp')
 
 gulp.task('downstream', function(){
-    gulp.src('path/to/source/language/*')
+    return gulp.src('path/to/source/language/*')
         .pipe(transifex.pullResource())
 })
 ```


### PR DESCRIPTION
Documentation should indicate that we must `return` the vfs stream from `gulp.src` in any case. There is no detriment to **always** returning the stream.

By adding the return in any use case, we allow gulp to properly detect when the task is complete. 
### Without a return:

```
 gulp build:lang
[09:26:08] Using gulpfile ~/dev/test/gulpfile.js
[09:26:08] Starting 'build:lang'...
[09:26:08] Finished 'build:lang' after 8.77 ms
[09:26:09] Downloading file: ca_regions.php
[09:26:09] ✔ fr ca_regions.php Downloaded: 
[09:26:09] Downloading file: ca_regions.php
[09:26:09] ✔ en ca_regions.php Downloaded: 
[09:26:10] Downloading file: countries.php
[09:26:15] File saved
```
### With a return

```
 gulp build:lang
[09:28:32] Using gulpfile ~/dev/test/gulpfile.js
[09:28:32] Starting 'build:lang'...
[09:28:33] Downloading file: ca_regions.php
[09:28:33] ✔ en ca_regions.php Downloaded: 
[09:28:33] Downloading file: ca_regions.php
[09:28:33] ✔ fr ca_regions.php Downloaded: 
[09:28:38] File saved
[09:28:38] Finished 'build:lang' after 1.92 s
```
